### PR TITLE
Display sponsor logos

### DIFF
--- a/src/components/blocks/LogoCard.astro
+++ b/src/components/blocks/LogoCard.astro
@@ -1,0 +1,8 @@
+---
+const { imgSrc, imgAltText } = Astro.props;
+import { Image } from "astro:assets";
+---
+
+<div class="h-32 w-32 flex items-center justify-center p-4 rounded-lg bg-white">
+  <Image class="max-h-full w-auto" src={imgSrc} alt={imgAltText} />
+</div>

--- a/src/components/blocks/Sponsors.astro
+++ b/src/components/blocks/Sponsors.astro
@@ -1,0 +1,14 @@
+---
+import LogoCard from "./LogoCard.astro";
+
+import build38Logo from "../../../public/img/sponsors/build38.png";
+import innoITLogo from "../../../public/img/sponsors/innoit.png";
+import siemensLogo from "../../../public/img/sponsors/siemens.png";
+
+---
+
+<div class="flex justify-center items-center gap-6 p-6">
+  <LogoCard imgSrc={build38Logo} imgAltText="Build38 logo" />
+  <LogoCard imgSrc={innoITLogo} imgAltText="InnoIT consulting logo" />
+  <LogoCard imgSrc={siemensLogo} imgAltText="Siemens Healthineers logo" />
+</div>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -12,6 +12,7 @@ import ValuesPhoto from "../../../public/img/pictures/bcncyber-meeting-room.jpeg
 import IconCardWithTitleSubtitle from '../../components/blocks/IconCardWithTitleSubtitle.astro';
 import CallToAction from '../../components/blocks/CallToAction.astro';
 import SmallTitle from '../../components/primitives/text/SmallTitle.astro';
+import Sponsors from '../../components/blocks/Sponsors.astro';
 const lang = "en"
 ---
 
@@ -66,12 +67,7 @@ const lang = "en"
 			<br/>
 			<br/>
 			<MediumTitle titleText="Backed by the best" extraCss="text-center p-4 md:p-0"/>
-			<div class="md:grid md:grid-cols-3 grid-cols-1 md:grid-rows-1 gap-16 mx-auto content-center w-5/6 md:w-2/3 p-6">
-				<Image class="w-4/5 mx-auto pb-4" src={build38Logo} alt="Build38 logo"/>
-				<Image class="w-4/5 mx-auto pb-4" src={innoITLogo} alt="InnoIT consulting logo"/>
-				<Image class="w-4/5 mx-auto pb-4" src={siemensLogo} alt="Siemens Healthineers logo"/>
-			</div>
-			<br/>
+				<Sponsors />
 		<br>
 	</main>
 	<Footer lang={lang}/>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -12,6 +12,7 @@ import ValuesPhoto from "../../../public/img/pictures/bcncyber-meeting-room.jpeg
 import IconCardWithTitleSubtitle from '../../components/blocks/IconCardWithTitleSubtitle.astro';
 import CallToAction from '../../components/blocks/CallToAction.astro';
 import SmallTitle from '../../components/primitives/text/SmallTitle.astro';
+import Sponsors from '../../components/blocks/Sponsors.astro';
 const lang = "es"
 ---
 
@@ -66,11 +67,7 @@ const lang = "es"
 			<br/>
 			<br/>
 			<MediumTitle titleText="Con soporte de los mejores" extraCss="text-center p-4 md:p-0"/>
-			<div class="md:grid md:grid-cols-2 grid-cols-1 md:grid-rows-1 gap-16 mx-auto content-center w-5/6 md:w-2/3 p-6">
-				<Image class="w-4/5 mx-auto pb-4" src={build38Logo} alt="Build38 logo"/>
-				<Image class="w-4/5 mx-auto pb-4" src={innoITLogo} alt="InnoIT consulting logo"/>
-				<Image class="w-4/5 mx-auto pb-4 hidden" src={siemensLogo} alt="Siemens Healthineers logo"/>
-			</div>
+			<Sponsors />
 			<br/>
 		<br>
 	</main>


### PR DESCRIPTION
The tricky thing with logos is that they often come in different sizes. The best way to display them is by wrapping each logo in a square box, limiting their max-width and max-height, and aligning them horizontally and vertically centered. This ensures that the logos not only fit within the box but also create visual consistency. As a result, each logo has an equivalent visual presence.

- Create a `LogoCard.astro` component to wrap the logo.
- Create a `Sponsors.astro `component to display the logos.
- Implement `Sponsors.astro` into both _en_ and _es_ home pages that use them.

The `LogoCard.astro` uses a white background as it seems to fit best the actual color scheme and overall design, but can be later changed. 