### PR TITLE
New design for Header

### DIFF
--- a/src/components/screens/Header.astro
+++ b/src/components/screens/Header.astro
@@ -93,56 +93,62 @@ let JoinTheCommunityString = getStringTranslation('JoinTheCommunityString', lang
 let LanguageString = getStringTranslation('LanguageString', lang);
 
 ---
-<header class="md:flex p-5 gap-5 max-w-screen-xl mx-auto">
-  <Astronav>
-    <div class="md:flex w-full justify-between items-center">
-      <a href={homeLink} class="hidden md:flex items-center space-x-3 rtl:space-x-reverse">
-        <img src="/img/bcncyber-logo-purple.png" class="h-16" alt="BCNCybersecurity Logo">
-      </a>
-      <div class="flex lg:hidden">
-        <MenuIcon class="w-8 h-8 text-gray-800 mr-4" />
-      </div>
-    <MenuItems class="hidden md:flex">
-        <ul class="md:flex w-full flex-col p-4 md:p-0 font-medium border border-gray-100 rounded-lg bg-gray-50 md:space-x-8 rtl:space-x-reverse md:flex-row md:mt-0 md:border-0 md:bg-white items-center">
-          <li class="pb-2 md:pb-0">
-            <a href={homeLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0" aria-current="page">{HomeString}</a>
-          </li>
-          <li class="pb-2 md:pb-0">
-            <a href={AboutTheProjectLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0">{AboutTheProjectString}</a>
-          </li>
-          <li class="pb-2 md:pb-0">
-            <a href={WhatWeDoLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0">{WhatWeDoString}</a>
-          </li>
-          <li class="pb-2 md:pb-0">
-            <a href={EventsLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0">{EventsString}</a>
-          </li>
-          <li class="pb-2 md:pb-0">
-            <a href={GalleryLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0">{GalleryString}</a>
-          </li>
-          <li class="pb-2 md:pb-0">
-            <a href={BlogLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0">{BlogString}</a>
-          </li>
-          <li class="md:hidden pb-2 md:pb-0">
-            <a href={JoinTheCommunityLink} class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0">{JoinTheCommunityString}</a>
-          </li>
-        </ul>
-        <a class="md:hidden order-2 space-x-0 rtl:space-x-reverse items-left underline" href={LanguageLink}>
-          <div>
-            {LanguageString}
-          </div>
-        </a>
-    </MenuItems>
 
-		<a class="hidden md:flex md:order-2 space-x-3 md:space-x-0 rtl:space-x-reverse md:items-center" href={JoinTheCommunityLink}>
-			<div>
-				<button type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 text-center">{JoinTheCommunityString}</button>
-			</div>
-		</a>
-		<a class="hidden md:flex md:order-2 space-x-3 md:space-x-0 rtl:space-x-reverse md:items-left underline" href={LanguageLink}>
-			<div>
-				{LanguageString}
-			</div>
-		</a>
+<header>
+  <div class="bg-black px-6 py-3">
+    <div class="max-w-[1100px] m-auto flex items-center justify-between">
+      <div class="text-xs text-white"><a href={LanguageLink}>{LanguageString}</a></div>
+ 
+      <a href={JoinTheCommunityLink} target="_blank">
+        <button
+          type="button"
+          class="text-white  border border-white hover:bg-[#465FFF] bg-[#827edc] rounded-full text-sm px-4 py-2 text-center"
+          >{JoinTheCommunityString} </button
+        >
+      </a>
+    </div>
   </div>
+
+  <Astronav>
+    <div class="p-6">
+      <div class="max-w-[1100px] m-auto">
+        <div class="md:flex w-full justify-between items-center">
+          <div class="flex justify-between">
+            <a href={homeLink}>
+              <img
+                src="/img/bcncyber-logo-purple.png"
+                class="h-16"
+                alt="BCNCybersecurity Logo"
+              />
+            </a>
+            <div class="flex md:hidden">
+              <MenuIcon class="w-8 h-8 text-inherit" />
+            </div>
+          </div>
+          <MenuItems class="hidden md:flex">
+            <ul class="md:flex w-full flex-col py-6 md:py-0 md:flex-row gap-3">
+              <li class="flex py-2 md:py-0 hover:text-[#827edc]">
+                <a href={homeLink} aria-current="page">{HomeString}</a>
+              </li>
+              <li class="flex py-2 md:py-0 hover:text-[#827edc]">
+                <a href={AboutTheProjectLink}>{AboutTheProjectString}</a>
+              </li>
+              <li class="flex py-2 md:py-0 hover:text-[#827edc]">
+                <a href={WhatWeDoLink}>{WhatWeDoString}</a>
+              </li>
+              <li class="flex py-2 md:py-0 hover:text-[#827edc]">
+                <a href={EventsLink}>{EventsString}</a>
+              </li>
+              <li class="flex py-2 md:py-0 hover:text-[#827edc]">
+                <a href={GalleryLink}>{GalleryString}</a>
+              </li>
+              <li class="flex py-2 md:py-0 hover:text-[#827edc]">
+                <a href={BlogLink}>{BlogString}</a>
+              </li>
+            </ul>
+          </MenuItems>
+        </div>
+      </div>
+    </div>
   </Astronav>
 </header>


### PR DESCRIPTION
The current header design combines the logo, navigation, a "Join the community" call to action, and an EN/ES language switch into a single block. This PR proposes splitting these elements into two distinct blocks: one for the primary components (logo and navigation) and another for the specific user interests ("Join the community" call to action and EN/ES language switch).

In this new version, when viewed on mobile devices, the specific user interests ("Join the community" call to action and EN/ES language switch) will be visible at the top. The logo will also remain visible. The navigation links will be displayed only when the menu button is clicked. 

To maintain visual consistency, the "Join the community" call to action has the same background color as the logo, as well as the navigation links when hovered.
 